### PR TITLE
allow underscore sign in identifiers (aka @param, etc)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -145,6 +145,8 @@ lazy val itExternal = (project in file("integration-tests/external-models"))
       Seq(
         s"-Xplugin:${pluginJar.getAbsolutePath}:${parserJar.getAbsolutePath}:${astJar.getAbsolutePath}",
         s"-Jdummy=${pluginJar.lastModified}", // ensures recompile
+        // https://github.com/sbt/zinc/issues/621
+        // "-Xshow-phases",
         "-Yrangepos")
     },
     Keys.`package` := { new File("") },

--- a/parser/src/main/scala/scaladoc/parser/ParseScaladocTags.scala
+++ b/parser/src/main/scala/scaladoc/parser/ParseScaladocTags.scala
@@ -43,7 +43,7 @@ final class ParseScaladocTags(val chars: Array[Char]) extends Tokenizer {
   }
 
   private def takeId(): String = {
-    val ident = takeWhile(x => x.isLetterOrDigit || x == '-')
+    val ident = takeWhile(x => x.isLetterOrDigit || x == '-' || x == '_')
     skipSpaces()
     ident
   }

--- a/parser/src/test/scala/scaladoc/parser/ParseScaladocTagsSpec.scala
+++ b/parser/src/test/scala/scaladoc/parser/ParseScaladocTagsSpec.scala
@@ -47,8 +47,9 @@ class ParseScaladocTagsSpec extends FSpec {
         |Description
         |
         |@param a one line description
+        |@param b_b underscore in the param name
         |
-        |@param b multi
+        |@param c multi
         |         line
         |         description
         |
@@ -57,6 +58,7 @@ class ParseScaladocTagsSpec extends FSpec {
     doc.textDescriptions must contain only ("Multi\nLine\nDescription")
     doc.textParams must contain only (
       "a" -> "one line description",
-      "b" -> "multi\nline\ndescription")
+      "b_b" -> "underscore in the param name",
+      "c" -> "multi\nline\ndescription")
   }
 }


### PR DESCRIPTION
should fix https://github.com/andyglow/scala-jsonschema/issues/188